### PR TITLE
output key 에서 address 쓰던코드에서 "0" 키만 참고하도록 변경

### DIFF
--- a/shell.py
+++ b/shell.py
@@ -63,7 +63,7 @@ class Shell:
 
     def ssd_read(self, address, for_script=False):
         os.system(f"python ssd.py R {address}")
-        result = self.read_output()[address]
+        result = self.read_output()["0"]
         if for_script:
             return result
         else:


### PR DESCRIPTION
## 🚀 작업 내용
ssd_output.txt 가 "0" 키값 고정 사용으로 결정

## ✅ Checklist
- [ ✅] 스스로 코드를 충분히 확인했나요?
- [ ✅] 코드 컨벤션을 준수했나요?
- [ ✅] 테스트 코드를 작성했나요?
- [ ✅] 관련 문서를 업데이트했나요?
